### PR TITLE
Add brew install helper and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# MD Local Setup
+
+This repository documents how to configure tools used for development and automation. Each setup step is provided via shell scripts so that it can be replicated easily.
+
+## Requirements
+
+The core requirement for all tooling is [Homebrew](https://brew.sh/). All other setup scripts expect `brew` to be available on your system.
+
+### Installing Homebrew
+
+Run the helper script from the `scripts` directory to install Homebrew. It will perform a check and skip installation if `brew` is already installed.
+
+```bash
+bash scripts/install_brew.sh
+```
+
+After Homebrew is installed you can add additional setup scripts for other tools in this repository.
+
+## Repository Structure
+
+- `scripts/` – collection of shell scripts used to install and configure tools. Currently only the Homebrew installation script is provided.
+
+Further instructions will be added as additional tools are incorporated.

--- a/scripts/install_brew.sh
+++ b/scripts/install_brew.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if command -v brew >/dev/null 2>&1; then
+    echo "Homebrew already installed. Skipping installation."
+    exit 0
+fi
+
+# Detect operating system
+OS="$(uname -s)"
+
+if [[ "$OS" == "Darwin" ]]; then
+    NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+elif [[ "$OS" == "Linux" ]]; then
+    NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+else
+    echo "Unsupported OS: $OS" >&2
+    exit 1
+fi
+
+brew --version


### PR DESCRIPTION
## Summary
- add initial README with instructions for installing Homebrew
- add `install_brew.sh` script to bootstrap Homebrew

## Testing
- `bash -n scripts/install_brew.sh`


------
https://chatgpt.com/codex/tasks/task_e_6850fd65ffd0832698087f9e685ccee3