### PR TITLE
Add missing mac setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,24 @@ The core requirement for all tooling is [Homebrew](https://brew.sh/). All other 
 
 ### Installing Homebrew
 
-Run the helper script from the `scripts` directory to install Homebrew. It will perform a check and skip installation if `brew` is already installed.
+Run the helper script from the `scripts` directory to install Homebrew. On macOS the script also installs the Xcode command line tools if they are missing and updates your `.zprofile` so `brew` is available in new shells. It will perform a check and skip installation if `brew` is already installed.
 
 ```bash
 bash scripts/install_brew.sh
 ```
 
-After Homebrew is installed you can add additional setup scripts for other tools in this repository.
+After Homebrew is installed you can add additional setup scripts for other tools in this repository. The repository now includes a helper to configure `zsh` with common plugins and utilities.
+
+### Configuring zsh
+
+Run the zsh setup script to install Oh My Zsh, useful plugins and command line utilities. Besides git, fzf, bat and direnv it also installs Warp, Ollama and Msty, configures the Powerlevel10k theme and adds handy aliases:
+
+```bash
+bash scripts/setup_zsh.sh
+```
 
 ## Repository Structure
 
-- `scripts/` – collection of shell scripts used to install and configure tools. Currently only the Homebrew installation script is provided.
+- `scripts/` – collection of shell scripts used to install and configure tools. Includes helpers for installing Homebrew and configuring zsh.
 
 Further instructions will be added as additional tools are incorporated.

--- a/scripts/install_brew.sh
+++ b/scripts/install_brew.sh
@@ -10,7 +10,13 @@ fi
 OS="$(uname -s)"
 
 if [[ "$OS" == "Darwin" ]]; then
+    if ! xcode-select -p >/dev/null 2>&1; then
+        echo "Installing Xcode command line tools..."
+        xcode-select --install
+    fi
     NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> "$HOME/.zprofile"
+    eval "$(/opt/homebrew/bin/brew shellenv)"
 elif [[ "$OS" == "Linux" ]]; then
     NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
     eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"

--- a/scripts/setup_zsh.sh
+++ b/scripts/setup_zsh.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install oh-my-zsh if not present
+if [[ ! -d "$HOME/.oh-my-zsh" ]]; then
+  RUNZSH=no KEEP_ZSHRC=yes sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+fi
+
+ZSH_CUSTOM="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}"
+
+# Clone plugins and theme if missing
+[[ -d "$ZSH_CUSTOM/plugins/zsh-autosuggestions" ]] || \
+  git clone https://github.com/zsh-users/zsh-autosuggestions "$ZSH_CUSTOM/plugins/zsh-autosuggestions"
+
+[[ -d "$ZSH_CUSTOM/plugins/zsh-syntax-highlighting" ]] || \
+  git clone https://github.com/zsh-users/zsh-syntax-highlighting "$ZSH_CUSTOM/plugins/zsh-syntax-highlighting"
+
+[[ -d "$ZSH_CUSTOM/themes/powerlevel10k" ]] || \
+  git clone --depth=1 https://github.com/romkatv/powerlevel10k.git "$ZSH_CUSTOM/themes/powerlevel10k"
+
+# Install useful utilities
+brew install git fzf bat direnv ollama msty >/dev/null
+brew install --cask warp >/dev/null
+
+ZSHRC="$HOME/.zshrc"
+
+# Configure theme
+if grep -q '^ZSH_THEME=' "$ZSHRC"; then
+  sed -i.bak 's/^ZSH_THEME=.*/ZSH_THEME="powerlevel10k\/powerlevel10k"/' "$ZSHRC"
+else
+  echo 'ZSH_THEME="powerlevel10k/powerlevel10k"' >> "$ZSHRC"
+fi
+
+# Configure plugins
+if grep -q '^plugins=' "$ZSHRC"; then
+  sed -i.bak 's/^plugins=.*/plugins=(git zsh-autosuggestions zsh-syntax-highlighting)/' "$ZSHRC"
+else
+  echo 'plugins=(git zsh-autosuggestions zsh-syntax-highlighting)' >> "$ZSHRC"
+fi
+
+# Add aliases if not already present
+grep -q "alias bat='bat --paging=never --style plain'" "$ZSHRC" || \
+  echo "alias bat='bat --paging=never --style plain'" >> "$ZSHRC"
+
+grep -q "alias fzfp='fzf --preview \"bat --style numbers --color always {}\"'" "$ZSHRC" || \
+  echo "alias fzfp='fzf --preview \"bat --style numbers --color always {}\"'" >> "$ZSHRC"
+
+# Source .zshrc to apply changes in current session if ZSH is running
+if [[ "$SHELL" == *"zsh"* ]]; then
+  source "$ZSHRC"
+fi
+


### PR DESCRIPTION
## Summary
- enhance `install_brew.sh` to install Xcode CLI and configure `.zprofile`
- add Warp, Ollama and Msty package installs to `setup_zsh.sh`
- document new behavior in README

## Testing
- `bash -n scripts/install_brew.sh`
- `bash -n scripts/setup_zsh.sh`

------
https://chatgpt.com/codex/tasks/task_e_68694d3f022c832686141df999f14268