### PR TITLE
Add Cloudflare Tunnel doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,15 @@ Tailscale connects locally hosted apps to your phone or other devices:
 brew install --cask tailscale
 ```
 
+### Cloudflare Tunnel
+
+Use Cloudflare's tunnel service to share local sites under the free plan. After running `cloudflared login`, start a tunnel for your app:
+
+```bash
+brew install cloudflared
+cloudflared tunnel --url http://localhost:8080
+```
+
 ### Docker Compose
 
 Docker Compose works with Docker running under Colima for container orchestration.


### PR DESCRIPTION
## Summary
- add steps for using Cloudflare Tunnel via the `cloudflared` client

## Testing
- `bash -n scripts/install_brew.sh && bash -n scripts/setup_zsh.sh`
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687ab33a8e0c83268436f6e0a4613f40